### PR TITLE
build: add syntax directive to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20.9-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20.9-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/Dockerfile.monitoring
+++ b/Dockerfile.monitoring
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM golang:1.21-alpine3.19 AS builder
 

--- a/Dockerfile.schedule
+++ b/Dockerfile.schedule
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20.9-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20.9-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add `# syntax=docker/dockerfile:1` directive to Dockerfiles to specify the Dockerfile syntax version