### PR TITLE
ci: remove custom branch and add workflow_dispatch event

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Build Docker images
 
 on:
   push:
-    branches: ["canary", "main", "feat/monitoring"]
+    branches: [main, canary]
+  workflow_dispatch:
 
 jobs:
   build-and-push-cloud-image:

--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -2,7 +2,8 @@ name: Dokploy Docker Build
 
 on:
   push:
-    branches: [main, canary, "1061-custom-docker-service-hostname"]
+    branches: [main, canary]
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: dokploy/dokploy


### PR DESCRIPTION
## Summary by Sourcery

Update deploy and dokploy GitHub Actions workflows to remove obsolete branch filters and enable manual dispatch

CI:
- Remove custom branch filters from push triggers in deploy and dokploy workflows
- Add workflow_dispatch triggers to allow manual runs of deploy and dokploy workflows